### PR TITLE
Make kill_ksampled binary actually kill ksampled

### DIFF
--- a/memtis-userspace/Makefile
+++ b/memtis-userspace/Makefile
@@ -14,7 +14,7 @@ launch_bench: launch_bench.c
 	${CC} ${CFLAGS} launch_bench.c -o ${DIR}/launch_bench
 
 kill_ksampled: kill_ksampled.c
-	${CC} ${CFLAGS} launch_bench.c -o ${DIR}/kill_ksampled
+	${CC} ${CFLAGS} kill_ksampled.c -o ${DIR}/kill_ksampled
 
 clean:
 	rm ${DIR}/launch_bench ${DIR}/launch_bench_nopid ${DIR}/kill_ksampled


### PR DESCRIPTION
There's a bug in the memtis-userspace Makefile: the target to compile `kill_ksampled.c` actually compiles `launch_bench.c` instead. So any bash script that invokes the `kill_ksampled` in an attempt to kill ksampled doesn't do so.

This PR fixes the Makefile by making it actually compile `kill_ksampled`.

You might want to re-run the paper experiments to see if the numbers change after the fix, and issue corrections if so.